### PR TITLE
releases: fix some scripting and styling issues on release page

### DIFF
--- a/themes/pcsx2/assets/sass/_general.sass
+++ b/themes/pcsx2/assets/sass/_general.sass
@@ -276,6 +276,8 @@ td
   > ul
     padding-left: 1rem
     margin: 0
+  > p
+    margin: 0
 
 // Pagination
 .btn-pagination

--- a/themes/pcsx2/assets/sass/_releases.sass
+++ b/themes/pcsx2/assets/sass/_releases.sass
@@ -75,4 +75,4 @@ a.disabled
   cursor: pointer
 
 .scroll-fix
-  scroll-margin-top: 10rem;
+  scroll-margin-top: 10rem

--- a/themes/pcsx2/layouts/_default/baseof.html
+++ b/themes/pcsx2/layouts/_default/baseof.html
@@ -23,9 +23,9 @@
         {{ end }}
     </div>
     <!-- javascript libraries that are used on every page -->
-    <script defer src="/js/vendor/mdb-ui-kit@3.10.2/mdb.min.js"></script>
-    <script defer src="/js/vendor/jquery@3.6.0/jquery.min.js"></script>
-    <script defer src="/js/theme.js"></script>
+    <script src="/js/vendor/mdb-ui-kit@3.10.2/mdb.min.js"></script>
+    <script src="/js/vendor/jquery@3.6.0/jquery.min.js"></script>
+    <script src="/js/theme.js"></script>
     <script src="/js/vendor/vanilla-lazyload@17.5.1/lazyload.min.js"></script>
     <script src="/js/vendor/cookieconsent@3.1.1/cookieconsent.min.js"></script>
     <script>

--- a/themes/pcsx2/layouts/page/compat.html
+++ b/themes/pcsx2/layouts/page/compat.html
@@ -106,8 +106,8 @@
 </div>
 {{ end }}
 {{ define "additionalScripts" }}
-<script defer src="/js/vendor/underscore@1.13.2/underscore-min.js"></script>
-<script defer src="/js/vendor/dot@1.1.3/doT.min.js"></script>
-<script defer src="/js/vendor/fuse.js@6.5.3/fuse.min.js"></script>
-<script defer src="/js/compat-table.js"></script>
+<script src="/js/vendor/underscore@1.13.2/underscore-min.js"></script>
+<script src="/js/vendor/dot@1.1.3/doT.min.js"></script>
+<script src="/js/vendor/fuse.js@6.5.3/fuse.min.js"></script>
+<script src="/js/compat-table.js"></script>
 {{ end }}

--- a/themes/pcsx2/layouts/page/downloads.html
+++ b/themes/pcsx2/layouts/page/downloads.html
@@ -75,7 +75,7 @@
     </div>
   </div>
   {{- partial "ads/horizontal-row.html" -}}
-  <div class="row mt-5" id="stable-list">
+  <div class="row mt-5 scroll-fix" id="stable-list">
     <h5>Stable Release List</h5>
   </div>
   <div class="row mt-2">
@@ -148,7 +148,7 @@
     </div>
   </div>
   {{- partial "ads/horizontal-row.html" -}}
-  <div class="row mt-5" id="nightly-list">
+  <div class="row mt-5 scroll-fix" id="nightly-list">
     <h5>Nightly Release List</h5>
   </div>
   <div class="row mt-2">
@@ -186,7 +186,7 @@
       request itself.
     </p>
   </div>
-  <div class="row mt-2" id="pull-requests-list">
+  <div class="row mt-2 scroll-fix" id="pull-requests-list">
     <div class="table-responsive">
       <table class="table table-sm" id="pull-request-table">
         <thead>
@@ -210,7 +210,7 @@
 </div>
 {{ end }}
 {{ define "additionalScripts" }}
-<script defer src="/js/vendor/dot@1.1.3/doT.min.js"></script>
-<script defer src="/js/vendor/marked@4.0.12/marked.min.js"></script>
-<script defer src="/js/release-page.js"></script>
+<script src="/js/vendor/dot@1.1.3/doT.min.js"></script>
+<script src="/js/vendor/marked@4.0.12/marked.min.js"></script>
+<script src="/js/release-page.js"></script>
 {{ end }}

--- a/themes/pcsx2/static/js/release-page.js
+++ b/themes/pcsx2/static/js/release-page.js
@@ -253,7 +253,7 @@ function renderPreviousReleases(category, noScroll) {
       url: release.url,
       releaseDate: new Date(release.createdAt).toLocaleDateString(),
       platforms: platforms,
-      releaseNotes: release.description == undefined ? null : marked(truncateDescription(release.description))
+      releaseNotes: release.description == undefined ? null : marked.parse(truncateDescription(release.description))
     };
     $(selector).append(releaseRow(templateData));
   }


### PR DESCRIPTION
I fixed the web-api to support CORS more generally -- now we can see the releases page in the CF preview pages, when i got it working i noticed it was broken!

This fixes the problems on the page, which you can confirm.

I havn't merged the backend CORS changes yet, they look good but im going to let them bake for 24hours.