### PR TITLE
Improve BIOS dumping instructions

### DIFF
--- a/content/guides/basic-setup/index.md
+++ b/content/guides/basic-setup/index.md
@@ -13,48 +13,54 @@ If you require further help, please visit our forums or ask in our Discord's hel
 
 ## How to dump your PS2 BIOS
 
-Dumping your PS2 BIOS requires a mod to your PS2 to allow arbitrary code execution.
+Dumping your PS2 BIOS is conceptually a two-step process:
+1. Modify the operation of your PS2 so that it can run any program.
+2. Then you can run a "BIOS dumper" utility program on your PS2 that reads its BIOS and writes it to a USB drive.
 
-**Popular options:**
+There is a generally useful program, uLaunchELF, that lets you browse memory cards, DVDs, and USB drives connected to a PS2 and run programs from them. So for most of the approaches below, you use uLaunchELF to then run the BIOS dumper.
+
+### Popular approaches to modify PS2 operation
 
 1. FreeMcBoot Memory Card
-    - Works for all but the newest (9xxxx serial number with a date code larger than 8B) slim PS2s. Can be found online for ~10 USD. Minimal effort.
+    - Works for all but the newest (9xxxx serial number with a date code larger than 8B) slim PS2s. Can be found online for ~10 USD.
 2. FreeDVDBoot
     - Works for many slim models, and some phat models. Slight effort, but free.
     - You will require a blank DVD for this method to work!
-      - It is recommended to use a **DVD-R** disc that supports atleast 4x speed, burned at 4x speed.
 3. Disc swap exploits
     - Technical in nature, involves hardware tampering. Guides can be found quickly by Googling.
 4. Mod chips
     - Extremely technical, requires soldering skills. DO NOT ATTEMPT unless you are an electronics pro.
 
-### Downloading the dumper utility
+### Downloading the BIOS dumper utility
 
 Hosted by the PCSX2 Project:
 - [Binary Version](https://github.com/PCSX2/tools/releases/download/bios-dumper%2Fv2/PS2dumperV2_bin.7z) (Recommended)
+  - After downloading, extract the files to a USB flash drive.
+    - Your mileage may vary here. All PS2 models can read and write to USB flash drives formatted with a FAT32 file system. Some people report USB 3.0 drives being usable while others claim they are not.  For this reason it appears to be more dependent on the drive rather than the USB version so we cannot provide an exhaustive list for success.
+
 - [ISO Version](https://github.com/PCSX2/tools/releases/download/bios-dumper%2Fv2/PS2dumperV2_iso.7z) (You will have to burn a DVD with the image)
 
 ### Option 1: Starting a PS2 with FreeMcBoot
 
 - Plug the FreeMcBoot memory card into memory card port 1
-- Turn on the PS2 with no disc inside.
+- Turn on your PS2 with no disc inside.
 - Select uLaunchELF from the menu.
 
 ### Option 2: Starting a PS2 with FreeDVDBoot
 
-- Download the ISO which matches your console: https://github.com/CTurt/FreeDVDBoot/tree/master/PREBUILT%20ISOs
+- Download the ISO which matches your console from https://github.com/CTurt/FreeDVDBoot/tree/master/PREBUILT%20ISOs
 - Burn the ISO to a DVD.
-  - It is recommended to use a **DVD-R** disc that supports atleast 4x speed, burned at 4x speed.
-- Insert the burned FreeDVDBoot disc, then reset/turn on the PS2. uLaunchELF should open.
+  - The most generally reliable media is a **DVD-R** disc, burned at a slow speed (4X speed should be fine).
+- Insert the burned FreeDVDBoot disc, then reset/turn on your PS2. uLaunchELF should open.
 
 ### Dumping the BIOS
 
-- Insert your USB flash drive with the BIOS dumper (binary version) on it.
-  - Your milage may vary here, some people report USB 3.0 drives being usable while others claim they are not.  For this reason it appears to be more-so dependent on the drive rather than the USB version so we cannot provide an exhaustive list for success.
-- Navigate uLaunchELF to the device named mass: and open it.
+- Insert your USB flash drive with the BIOS dumper (binary version) on it into your PS2.
+- In uLaunchELF, navigate to the device named `mass:` and open it.
 - Locate and run `DUMPBIOS-MASS.ELF`.
+  - this will print some useful information about the BIOS, then print `Dumping BIOS Completed OK`... ending with `Dumping NVM Completed OK`
 
-If you have a `.bin`, `.nvm`, `.mec` and more files named after your PS2's serial number, your PS2 BIOS is dumped successfully.
+You can remove your USB flash drive from your PS2 after the last `Dumping` message and inspect its contents on your PC; if it has files ending in `.BIN`, `.NVM`, `ROM1`, and more all named after your PS2's serial number, then your PS2's BIOS was dumped successfully!
 
 ## Dumping PS2 Discs via ImgBurn
 


### PR DESCRIPTION
In Basic Setup Guide
* explain the steps, and the intermediate uLaunchELF
* replace 'mod your PS2' with '"hack" your PS2'
* explain which methods boot into uLaunchELF
* add step of extracting PS2dumper files to USB afte downloading them.
* move USB format recommendation to this step.
* mention FAT32 vs. exFAT file formats for USB flash drive
* only mention DVD-R recommendations once.
* describe what happens during PS2 dumper operation.