### PR TITLE
theme: adjust aspect ratios on image comparison sliders

### DIFF
--- a/themes/pcsx2/layouts/_default/baseof.html
+++ b/themes/pcsx2/layouts/_default/baseof.html
@@ -10,6 +10,7 @@
     }
 </script>
 {{- partial "head.html" . -}}
+
 <body>
     <div class="d-flex flex-column min-vh-100">
         {{- partial "navbar.html" . -}}
@@ -28,7 +29,16 @@
     <script src="/js/vendor/vanilla-lazyload@17.5.1/lazyload.min.js"></script>
     <script src="/js/vendor/cookieconsent@3.1.1/cookieconsent.min.js"></script>
     <script>
-        const lazyLoadInstance = new LazyLoad({});
+        const lazyLoadInstance = new LazyLoad({
+            callback_loaded: (imgElem) => {
+                // Fix image comparison aspect-ratios, has to be done here as the image hasn't loaded yet
+                if ($(imgElem).parent().hasClass("img-compare-container")) {
+                    let aspectRatio = imgElem.naturalWidth / imgElem.naturalHeight;
+                    // jQuery does not yet support .css'ing this option, looks pretty new
+                    $(imgElem).parent().attr("style", `aspect-ratio: ${aspectRatio};`);
+                }
+            },
+        });
 
         function loadGoogleAds() {
             $.getScript("https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0996284081546238", () => {


### PR DESCRIPTION
Images for the comparison sliders have to have their `height`s manipulated for the rest of the styling/elements around them to layout properly.

Because of this, the aspect ratio is not preserved.  This assumes both images are the same (they should be for comparison sliders...) and manually sets the aspect ratio on the containing div.