### PR TITLE
tools: add some basic spellcheck configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "streetsidesoftware.code-spell-checker",
+    "yzhang.markdown-all-in-one",
+    "budparr.language-hugo-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,4 +8,7 @@
     "editor.wordBasedSuggestions": false,
     "editor.snippetSuggestions": "top"
   },
+  "cSpell.files": [
+    "**/*.md"
+  ],
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -25,3 +25,6 @@ tasks:
   migrate-legacy:
     cmds:
       - python ./scripts/migrate-article.py
+  spell:
+    cmds:
+      - npx cspell content/**/*.md

--- a/content/guides/basic-setup/index.md
+++ b/content/guides/basic-setup/index.md
@@ -37,7 +37,6 @@ Hosted by the PCSX2 Project:
 - [Binary Version](https://github.com/PCSX2/tools/releases/download/bios-dumper%2Fv2/PS2dumperV2_bin.7z) (Recommended)
   - After downloading, extract the files to a USB flash drive.
     - Your mileage may vary here. All PS2 models can read and write to USB flash drives formatted with a FAT32 file system. Some people report USB 3.0 drives being usable while others claim they are not.  For this reason it appears to be more dependent on the drive rather than the USB version so we cannot provide an exhaustive list for success.
-
 - [ISO Version](https://github.com/PCSX2/tools/releases/download/bios-dumper%2Fv2/PS2dumperV2_iso.7z) (You will have to burn a DVD with the image)
 
 ### Option 1: Starting a PS2 with FreeMcBoot

--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "CCPA",
+    "devblog",
+    "Ninite",
+    "PCSX",
+    "PCSX2",
+    "unencrypted",
+    "webp"
+  ],
+  "patterns": [
+    {
+      "name": "authorName",
+      "pattern": "/mainAuthor:.*/g"
+    },
+    {
+      "name": "shortcodes",
+      "pattern": "/{{<.*>}}/g"
+    }
+  ],
+  "ignoreRegExpList": [
+    "authorName",
+    "shortcodes"
+  ]
+}


### PR DESCRIPTION
Not adding to CI as the false positives in our situation will be quite high, we'll just always having a failing job.

But adds extension recommendations to get spellchecking locally and a sample command to run it on all markdown files.  Running it on one would look something like:
`npx cspell content/**/new-website/*.md`
