### PR TITLE
Q4-2021: Force charts javascript version

### DIFF
--- a/themes/pcsx2/layouts/_default/baseof.html
+++ b/themes/pcsx2/layouts/_default/baseof.html
@@ -25,7 +25,7 @@
     <!-- javascript libraries that are used on every page -->
     <script src="/js/vendor/mdb-ui-kit@3.10.2/mdb.min.js"></script>
     <script src="/js/vendor/jquery@3.6.0/jquery.min.js"></script>
-    <script src="/js/theme.js"></script>
+    <script src="/js/theme.js?ver=1.0"></script>
     <script src="/js/vendor/vanilla-lazyload@17.8.1/lazyload.min.js"></script>
     <script src="/js/vendor/cookieconsent@3.1.1/cookieconsent.min.js"></script>
     <script>


### PR DESCRIPTION
You get issues that it caches old version of the charts file when for example using the preview site and when it goes live you don't have the correct latest version.

This should force it to not be cached for users which is helpful for future fixes or additions to older progress reports.