### PR TITLE
Specify a working version of biosdrain (v2.0.0 seems buggy)

### DIFF
--- a/content/guides/basic-setup/index.md
+++ b/content/guides/basic-setup/index.md
@@ -211,7 +211,7 @@ There is a generally useful program, uLaunchELF, that lets you browse memory car
 
 Our recommended BIOS dumper utility is [biosdrain](https://github.com/F0bes/biosdrain). Therefore the instructions below will be for this tool.
 
-- The download for the latest stable biosdrain is  [here](https://github.com/f0bes/biosdrain/releases/latest/download/biosdrain.elf).
+- The recommanded version of biosdrain is [here](https://github.com/F0bes/biosdrain/releases/download/v1.0.0/biosdrain.elf).
 
 ### Option 1: Starting a PS2 with FreeMcBoot
 


### PR DESCRIPTION
Need you opinion

It seems from my tests that [v2.0.0 of biosdrain](https://github.com/F0bes/biosdrain/releases/tag/v2.0.0) is buggy.
Being the latest version, the user will download this v2 and then may wonder why his dump is not working.

Is it interesting to have the working [v1.0.0](https://github.com/F0bes/biosdrain/releases/tag/v1.0.0) linked to the user rather than the latest version that may not work as intended ?