### PR TITLE
Move nightlies above stable

### DIFF
--- a/themes/pcsx2/layouts/page/downloads.html
+++ b/themes/pcsx2/layouts/page/downloads.html
@@ -5,10 +5,10 @@
     <nav id="TableOfContents">
       <ul>
         <li>
-          <a href="#stable-anchor">Stable Releases</a>
+          <a href="#nightly-anchor">Nightly Releases (aka Dev Builds)</a>
         </li>
         <li>
-          <a href="#nightly-anchor">Nightly Releases (aka Dev Builds)</a>
+          <a href="#stable-anchor">Stable Releases</a>
         </li>
         <li>
           <a href="#pr-anchor">Pull Request Builds</a>
@@ -40,6 +40,76 @@
           </div>
         </div>
       </div>
+    </div>
+    <div class="row mt-5">
+      <h2 class="release-type-title scroll-fix" id="nightly-anchor">Nightly Builds</h2>
+      <p>
+        Nightly builds are based on the latest in-developement version. As a result, these releases are intended
+        for those who want to, or require, being on the bleeding edge. They may contain unresolved bugs or issues,
+        use at your own discretion with this in mind. For information on how to get started with using PCSX2 (Dumping
+        your BIOS and games), <a href="/guides/basic-setup" data-test-id="setup-guide">see the following guide</a>.
+      </p>
+      <p>
+        For information on how to use the nightly releases <a
+          href="https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide" target="blank">see here</a>.
+      </p>
+      <div id="latest-nightly-notes"></div>
+    </div>
+    <div class="row mt-5 d-flex justify-content-center" id="latest-nightly-artifacts"></div>
+    <div class="row skeleton-wrapper" data-test-id="latest-nightly-artifacts-loading">
+      <div class="col-12 col-sm mb-4 d-flex justify-content-center">
+        <div class="dropdown">
+          <button class="btn btn-primary artifact-dropdown btn-lg dropdown-toggle" type="button" id="dropdownMenuButton"
+            data-mdb-toggle="dropdown" aria-expanded="false" disabled>
+            <div class="spinner-border" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+          </button>
+        </div>
+      </div>
+      <div class="col-12 col-sm mb-4 d-flex justify-content-center">
+        <div class="dropdown">
+          <button class="btn btn-primary artifact-dropdown btn-lg dropdown-toggle" type="button" id="dropdownMenuButton"
+            data-mdb-toggle="dropdown" aria-expanded="false" disabled>
+            <div class="spinner-border" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+          </button>
+        </div>
+      </div>
+      <div class="col-12 col-sm d-flex justify-content-center">
+        <div class="dropdown">
+          <button class="btn btn-primary artifact-dropdown btn-lg dropdown-toggle" type="button" id="dropdownMenuButton"
+            data-mdb-toggle="dropdown" aria-expanded="false" disabled>
+            <div class="spinner-border" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
+    {{- partial "ads/horizontal-row.html" -}}
+    <div class="row mt-5 scroll-fix" id="nightly-list">
+      <h5>Nightly Release List</h5>
+    </div>
+    <div class="row mt-2">
+      <div class="table-responsive">
+        <table class="table table-sm" id="nightly-table">
+          <thead>
+            <tr>
+              <th scope="col">Version</th>
+              <th scope="col">Download Links</th>
+              <th scope="col">Release Date</th>
+              <th scope="col">Description</th>
+            </tr>
+          </thead>
+          <tbody id="nightly-table-body">
+            <!-- skeleton loading -->
+            {{- partial "downloads/skeleton-table.html" (dict "numRows" 10 "numCols" 4) -}}
+          </tbody>
+        </table>
+      </div>
+      <div class="row justify-content-end mt-3 pagination-container" id="nightly-pagination-container"></div>
     </div>
     <h2 class="release-type-title mt-3 scroll-fix" id="stable-anchor">Stable Releases</h2>
     <p>
@@ -109,77 +179,6 @@
       </table>
     </div>
     <div class="row justify-content-end mt-3 pagination-container" id="stable-pagination-container"></div>
-  </div>
-
-  <div class="row mt-5">
-    <h2 class="release-type-title scroll-fix" id="nightly-anchor">Nightly Builds</h2>
-    <p>
-      Nightly builds are based on the latest in-developement version. As a result, these releases are intended
-      for those who want to, or require, being on the bleeding edge. They may contain unresolved bugs or issues,
-      use at your own discretion with this in mind. For information on how to get started with using PCSX2 (Dumping
-      your BIOS and games), <a href="/guides/basic-setup" data-test-id="setup-guide">see the following guide</a>.
-    </p>
-    <p>
-      For information on how to use the nightly releases <a
-        href="https://github.com/PCSX2/pcsx2/wiki/Nightly-Build-Usage-Guide" target="blank">see here</a>.
-    </p>
-    <div id="latest-nightly-notes"></div>
-  </div>
-  <div class="row mt-5 d-flex justify-content-center" id="latest-nightly-artifacts"></div>
-  <div class="row skeleton-wrapper" data-test-id="latest-nightly-artifacts-loading">
-    <div class="col-12 col-sm mb-4 d-flex justify-content-center">
-      <div class="dropdown">
-        <button class="btn btn-primary artifact-dropdown btn-lg dropdown-toggle" type="button" id="dropdownMenuButton"
-          data-mdb-toggle="dropdown" aria-expanded="false" disabled>
-          <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
-          </div>
-        </button>
-      </div>
-    </div>
-    <div class="col-12 col-sm mb-4 d-flex justify-content-center">
-      <div class="dropdown">
-        <button class="btn btn-primary artifact-dropdown btn-lg dropdown-toggle" type="button" id="dropdownMenuButton"
-          data-mdb-toggle="dropdown" aria-expanded="false" disabled>
-          <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
-          </div>
-        </button>
-      </div>
-    </div>
-    <div class="col-12 col-sm d-flex justify-content-center">
-      <div class="dropdown">
-        <button class="btn btn-primary artifact-dropdown btn-lg dropdown-toggle" type="button" id="dropdownMenuButton"
-          data-mdb-toggle="dropdown" aria-expanded="false" disabled>
-          <div class="spinner-border" role="status">
-            <span class="visually-hidden">Loading...</span>
-          </div>
-        </button>
-      </div>
-    </div>
-  </div>
-  {{- partial "ads/horizontal-row.html" -}}
-  <div class="row mt-5 scroll-fix" id="nightly-list">
-    <h5>Nightly Release List</h5>
-  </div>
-  <div class="row mt-2">
-    <div class="table-responsive">
-      <table class="table table-sm" id="nightly-table">
-        <thead>
-          <tr>
-            <th scope="col">Version</th>
-            <th scope="col">Download Links</th>
-            <th scope="col">Release Date</th>
-            <th scope="col">Description</th>
-          </tr>
-        </thead>
-        <tbody id="nightly-table-body">
-          <!-- skeleton loading -->
-          {{- partial "downloads/skeleton-table.html" (dict "numRows" 10 "numCols" 4) -}}
-        </tbody>
-      </table>
-    </div>
-    <div class="row justify-content-end mt-3 pagination-container" id="nightly-pagination-container"></div>
   </div>
   <div class="row mt-5">
     <h2 class="release-type-title scroll-fix" id="pr-anchor">Pull Request Builds</h2>


### PR DESCRIPTION
There seems to be a problem with computer peripheral manufacturers in the year 2022. There's an ever increasing number of users who, upon visiting our downloads page, are unable to access our nightly builds. This appears to be directly related to peripheral manufacturers removing scroll wheels from mice. This is making it increasingly difficult for users to navigate the page. Furthermore the monitor manufacturers seem to be plotting against us too, by blurring the left side of screens. This then makes it impossible for users to locate our jump links at the top left of the page.

This PR addresses both of these, by simply switching the order of the builds, and the jump links to match. I figure if the computing industry wants to make it impossible for our users to use their scroll wheels, or read a list of jump links, then the least we can do is switch the order to help them out.

Alright I'm done being snide, y'all know how I feel about this problem and how this PR _should not be necessary but apparently is_.

I moved the layout around, I have no idea if this is actually the right way to do it, someone please review.