### PR TITLE
downloads: add a tooltip on the homepage encouraging nightly usage

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,6 +9,7 @@ import {
   Card,
   Grid,
   Container,
+  Tooltip,
   getDocumentTheme,
 } from "@nextui-org/react";
 import { NumberTicker } from "../components/NumberTicker";
@@ -187,13 +188,24 @@ export default function Home() {
               justify="center"
             >
               <Grid>
-                <ReleaseDownloadButton
-                  release={latestStableRelease}
-                  buttonText={"Latest Stable"}
-                  isNightly={false}
-                  errorMsg={apiErrorMsg}
-                  placement={useMediaQuery(960) ? "bottom-left" : "left-top"}
-                />
+                <Tooltip
+                  content={
+                    <span style={{ color: "black" }}>
+                      We recommend using the latest nightly instead!
+                    </span>
+                  }
+                  color="warning"
+                  trigger="hover"
+                  placement="bottom"
+                >
+                  <ReleaseDownloadButton
+                    release={latestStableRelease}
+                    buttonText={"Latest Stable"}
+                    isNightly={false}
+                    errorMsg={apiErrorMsg}
+                    placement={useMediaQuery(960) ? "bottom-left" : "left-top"}
+                  />
+                </Tooltip>
               </Grid>
               <Grid>
                 <ReleaseDownloadButton


### PR DESCRIPTION
It's not perfect behavior wise (the tooltip will come back when the dropdown is clicked away from).  But this ultimately is a temporary warning that will go away when the next stable is launched, and the positioning doesn't get in the way.
![image](https://user-images.githubusercontent.com/13153231/207237664-584ec7e3-3f25-4ff5-9fc5-1ea9c59a796e.png)
