### PR TITLE
DownloadButton: Fix stable AppImage not showing

### DIFF
--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -129,7 +129,7 @@ export function ReleaseDownloadButton({
           release.linux,
           "linux",
           release.linux?.assets?.Linux,
-          ["Linux", "AppImage"],
+          ["Linux"],
           isNightly
         )
       );
@@ -139,7 +139,7 @@ export function ReleaseDownloadButton({
           release,
           "linux",
           release.assets?.Linux,
-          ["Linux", "AppImage"],
+          ["Linux"],
           isNightly
         )
       );


### PR DESCRIPTION
Stable just shows 32bit, whilst the Nightly says Appimage - x64 Qt

Stable:

![image](https://github.com/PCSX2/pcsx2-net-www/assets/24227051/34701188-77ae-4f46-b2f8-615e969f5fa7)

Nightly:

![image](https://github.com/PCSX2/pcsx2-net-www/assets/24227051/8937d92f-069b-49e0-98ce-9a1cacef61d1)
