### PR TITLE
DownloadButton: Fix formatting Windows, Linux and Apple

### DIFF
--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -6,6 +6,7 @@ import { IoIosCloudyNight } from "react-icons/io";
 import { GiBrickWall } from "react-icons/gi";
 import { useMediaQuery } from "../../utils/mediaQuery";
 
+// Function to get the latest release for a specific platform
 export function getLatestRelease(releases, platform) {
   for (const release of releases) {
     if (platform in release.assets && release.assets[platform].length > 0) {
@@ -15,12 +16,14 @@ export function getLatestRelease(releases, platform) {
   return undefined;
 }
 
+// Function to convert text to proper case
 function toProperCase(str) {
   return str.replace(/\w\S*/g, function (txt) {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
   });
 }
 
+// Function to get the OS icon based on the platform
 function getOSIcon(os, fillColor) {
   if (os === "windows") {
     return <BsWindows size={22} fill={fillColor}></BsWindows>;
@@ -33,6 +36,7 @@ function getOSIcon(os, fillColor) {
   }
 }
 
+// Function to generate dropdown items based on release assets
 function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
   if (!assets) {
     return [];
@@ -60,14 +64,17 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     }
 
-    // This will append "App" to the release for cleaner looking formatting for the downloads dropdown on pcsx2.net frontpage and downloads page
-    if (os === "macos") {
-      displayName = `App - ${displayName}`;
-    }
-
-    // This will append "Exe" to the release for cleaner looking formatting for the downloads dropdown on pcsx2.net frontpage and downloads page
+    // Generate a more dynamic displayName based on asset properties
     if (os === "windows") {
-      displayName = `Exe - ${displayName}`;
+      displayName = `Exe - ${os} - ${displayName}`;
+    } else if (os === "linux") {
+      if (asset.additionalTags.includes("appimage")) {
+        displayName = `AppImage - ${os} - ${displayName}`;
+      } else if (asset.additionalTags.includes("flatpak")) {
+        displayName = `Flatpak - ${os} - ${displayName}`;
+      }
+    } else if (os === "macos") {
+      displayName = `App.tar - ${os} - ${displayName}`;
     }
 
     items.push(
@@ -84,13 +91,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
   return items;
 }
 
-function openAssetLink(href) {
-  Object.assign(document.createElement("a"), {
-    rel: "noopener noreferrer",
-    href: href,
-  }).click();
-}
-
+// Component for the Release Download Button
 export function ReleaseDownloadButton({
   release,
   buttonText,
@@ -99,6 +100,7 @@ export function ReleaseDownloadButton({
   isNightly,
   placement,
 }) {
+  // Styling for the button
   const buttonStyling = {
     minWidth: "200px",
   };
@@ -107,10 +109,12 @@ export function ReleaseDownloadButton({
     buttonStyling.bgColor = "var(--nightly-button-background)";
   }
 
+  // States to hold dropdown items for each platform
   const [windowsItems, setWindowsItems] = useState([]);
   const [linuxItems, setLinuxItems] = useState([]);
   const [macosItems, setMacosItems] = useState([]);
 
+  // Effect to generate dropdown items when the release or other inputs change
   useEffect(() => {
     if ("windows" in release) {
       setWindowsItems(
@@ -175,8 +179,9 @@ export function ReleaseDownloadButton({
         )
       );
     }
-  }, [release]);
+  }, [release, isNightly]);
 
+  // Render the dropdown button and menu
   return (
     <Dropdown
       isBordered
@@ -189,7 +194,7 @@ export function ReleaseDownloadButton({
         css={buttonStyling}
         bordered={bordered}
       >
-        {isNightly ? <IoIosCloudyNight size={22} /> : <GiBrickWall size={16} />}
+        {isNightly ? <GiBrickWall size={16} /> : null}
         &nbsp;
         {buttonText}
       </Dropdown.Button>
@@ -197,7 +202,7 @@ export function ReleaseDownloadButton({
         color={isNightly ? "warning" : "primary"}
         aria-label="Actions"
         css={{ $$dropdownMenuWidth: "100%" }}
-        onAction={(assetUrl) => openAssetLink(assetUrl)}
+        // Removed onAction handler to avoid extra clickable modifications
       >
         <Dropdown.Section
           title={

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -82,7 +82,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     } else if (os === "macos") {
       displayName = "Download";
     }
-	
+
     // Strip the "- x64 Qt" for Linux
     if (os === "linux") {
       displayName = displayName.replace(/- x64 Qt$/, "");

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -71,9 +71,10 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     if (os === "windows") {
       displayName = "Download";
     } else if (os === "linux") {
-      // Check for Flatpak or AppImage tags
+      // Check for Flatpak or AppImage tags which will make Appimage - x64 Qt and Flatpak - x64 Qt and no way to seemingly fix the regular way
       if (asset.additionalTags.includes("appimage")) {
-        displayName = "AppImage";
+        displayName =
+          "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage" because tags failing to uppercase it
       } else if (asset.additionalTags.includes("flatpak")) {
         displayName = "Flatpak";
       }
@@ -81,7 +82,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       displayName = "Download";
     }
 
-    // Strip the "- x64 Qt" for Linux
+    // Strip the "- x64 Qt" for Linux because it's being annoying with the tags and who cares about how good the code looks for now it's a bit of jank.
     if (os === "linux") {
       displayName = displayName.replace(/- x64 Qt$/, "");
     }

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -73,8 +73,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     } else if (os === "linux") {
       // Check for Flatpak or AppImage tags which will make Appimage - x64 Qt and Flatpak - x64 Qt and no way to seemingly fix the regular way
       if (asset.additionalTags.includes("appimage")) {
-        displayName =
-          "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage" because tags failing to uppercase it
+        displayName = "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage" because tags failing to uppercase it
       } else if (asset.additionalTags.includes("flatpak")) {
         displayName = "Flatpak";
       }

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -73,7 +73,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     } else if (os === "linux") {
       // Check for Flatpak or AppImage tags which will make Appimage - x64 Qt and Flatpak - x64 Qt and no way to seemingly fix the regular way
       if (asset.additionalTags.includes("appimage")) {
-        displayName = "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage" because tags failing to uppercase it
+        displayName = "AppImage";
       } else if (asset.additionalTags.includes("flatpak")) {
         displayName = "Flatpak";
       }
@@ -82,8 +82,11 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     }
 
     // Strip the "- x64 Qt" for Linux because it's being annoying with the tags and who cares about how good the code looks for now it's a bit of jank.
+    // Replace "Appimage" with "AppImage" as the tags don't seem to work properly, so just replace the whole thing
     if (os === "linux") {
-      displayName = displayName.replace(/- x64 Qt$/, "");
+      displayName = displayName
+        .replace(/- x64 Qt$/, "")
+        .replace("Appimage", "AppImage");
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -69,17 +69,15 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 
     // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
-      displayName = `7z Archived Exe - x64 - Qt`;
+      displayName = `7z Archived Exe`;
     } else if (os === "linux") {
       if (asset.additionalTags.includes("flatpak")) {
-        displayName = `Flatpak - x64 - Qt`;
+        displayName = `Flatpak`;
       } else if (asset.additionalTags.includes("appimage")) {
-        displayName = `AppImage - x64 - Qt`;
-      } else {
-        displayName = `x64 - Qt`;
+        displayName = `AppImage`;
       }
     } else if (os === "macos") {
-      displayName = `xz Archived App - x64 - Qt`;
+      displayName = `xz Archived App`;
     } else {
       displayName = `${os.charAt(0).toUpperCase() + os.slice(1)} - x64 - Qt`;
     }

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -71,9 +71,13 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     if (os === "windows") {
       displayName = "Download";
     } else if (os === "linux") {
-      // Check for Flatpak or AppImage tags which will make Appimage - x64 Qt and Flatpak - x64 Qt and no way to seemingly fix the regular way
+      // Check for Flatpak or AppImage tags
       if (asset.additionalTags.includes("appimage")) {
-        displayName = "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage" because tags failing to uppercase it
+        // Appimage gets shown instead due to problems with the tags, so strip it and append it
+        displayName =
+          "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage"
+        displayName = displayName.replace("image", ""); // Strip "image"
+        displayName = displayName + "Image"; // Append "Image"
       } else if (asset.additionalTags.includes("flatpak")) {
         displayName = "Flatpak";
       }

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -16,10 +16,14 @@ export function getLatestRelease(releases, platform) {
   return undefined;
 }
 
-// Function to convert text to proper case
+// Function to convert text to proper case, skipping capitalizing "x64"
 function toProperCase(str) {
   return str.replace(/\w\S*/g, function (txt) {
-    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    if (txt.toLowerCase() === "x64") {
+      return txt.toLowerCase();
+    } else {
+      return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+    }
   });
 }
 
@@ -36,7 +40,7 @@ function getOSIcon(os, fillColor) {
   }
 }
 
-// Function to generate dropdown items based on release assets
+  // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
 function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
   if (!assets) {
     return [];

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -40,7 +40,6 @@ function getOSIcon(os, fillColor) {
   }
 }
 
-// Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
 function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
   if (!assets) {
     return [];
@@ -68,7 +67,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     }
 
-    // Generate a more dynamic displayName based on asset properties
+// Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
       displayName = `Exe - ${displayName}`;
     } else if (os === "linux") {

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -72,13 +72,20 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       displayName = "Download";
     } else if (os === "linux") {
       // Check for Flatpak or AppImage tags
-      if (asset.additionalTags.includes("flatpak")) {
-        displayName = "Flatpak";
-      } else if (asset.additionalTags.includes("appimage")) {
+      if (asset.additionalTags.includes("appimage")) {
         displayName = "AppImage";
+      } else if (asset.additionalTags.includes("flatpak")) {
+        displayName = "Flatpak";
+      } else {
+        displayName = "Linux"; // Default to "Linux" if no recognized tags
       }
     } else if (os === "macos") {
       displayName = "Download";
+    }
+	
+    // Strip the "- x64 Qt" for Linux
+    if (os === "linux") {
+      displayName = displayName.replace(/- x64 Qt$/, "");
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -60,6 +60,16 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     }
 
+    // This will append "App" to the release for cleaner looking formatting for the downloads dropdown on pcsx2.net frontpage and downloads page
+    if (os === "macos") {
+      displayName = `App - ${displayName}`;
+    }
+
+    // This will append "Exe" to the release for cleaner looking formatting for the downloads dropdown on pcsx2.net frontpage and downloads page
+    if (os === "windows") {
+      displayName = `Exe - ${displayName}`;
+    }
+
     items.push(
       <Dropdown.Item
         key={asset.url}

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -69,7 +69,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 
     // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
-      displayName = `7z Archived Exe`;
+      displayName = `7z Archive`;
     } else if (os === "linux") {
       if (asset.additionalTags.includes("flatpak")) {
         displayName = `Flatpak`;
@@ -77,7 +77,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
         displayName = `AppImage`;
       }
     } else if (os === "macos") {
-      displayName = `xz Archived App`;
+      displayName = `tar.xz Archive`;
     } else {
       displayName = `${os.charAt(0).toUpperCase() + os.slice(1)} - x64 - Qt`;
     }

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -67,9 +67,9 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     }
 
-    // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
+    // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt) as a fallback
     if (os === "windows") {
-      displayName = `7z Archive`;
+      displayName = `Archive`;
     } else if (os === "linux") {
       if (asset.additionalTags.includes("flatpak")) {
         displayName = `Flatpak`;
@@ -77,9 +77,9 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
         displayName = `AppImage`;
       }
     } else if (os === "macos") {
-      displayName = `tar.xz Archive`;
+      displayName = `Archive`;
     } else {
-      displayName = `${os.charAt(0).toUpperCase() + os.slice(1)} - x64 - Qt`;
+      displayName = `${displayName}`; // Keep the original display name
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -69,7 +69,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 
     // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt) as a fallback
     if (os === "windows") {
-      displayName = `Archive`;
+      displayName = `Download`;
     } else if (os === "linux") {
       if (asset.additionalTags.includes("flatpak")) {
         displayName = `Flatpak`;
@@ -77,7 +77,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
         displayName = `AppImage`;
       }
     } else if (os === "macos") {
-      displayName = `Archive`;
+      displayName = `Download`;
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -69,15 +69,19 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 
     // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
-      displayName = `Exe - ${displayName}`;
+      displayName = `Exe - x64 - Qt`;
     } else if (os === "linux") {
-      if (asset.additionalTags.includes("appimage")) {
-        displayName = `AppImage - ${displayName}`;
-      } else if (asset.additionalTags.includes("flatpak")) {
-        displayName = `Flatpak - ${displayName}`;
+      if (asset.additionalTags.includes("flatpak")) {
+        displayName = `Flatpak - x64 - Qt`;
+      } else if (asset.additionalTags.includes("appimage")) {
+        displayName = `AppImage - x64 - Qt`;
+      } else {
+        displayName = `Linux - x64 - Qt`;
       }
     } else if (os === "macos") {
-      displayName = `App - ${displayName}`;
+      displayName = `App - x64 - Qt`;
+    } else {
+      displayName = `Unknown - x64 - Qt`; // Fallback for other OS
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -67,17 +67,18 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     }
 
-    // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt) as a fallback
+    // Generate a more dynamic displayName based on asset properties, old way was following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
-      displayName = `Download`;
+      displayName = "Download";
     } else if (os === "linux") {
+      // Check for Flatpak or AppImage tags
       if (asset.additionalTags.includes("flatpak")) {
-        displayName = `Flatpak`;
+        displayName = "Flatpak";
       } else if (asset.additionalTags.includes("appimage")) {
-        displayName = `AppImage`;
+        displayName = "AppImage";
       }
     } else if (os === "macos") {
-      displayName = `Download`;
+      displayName = "Download";
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -96,6 +96,13 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 }
 
 // Component for the Release Download Button
+function openAssetLink(href) {
+  Object.assign(document.createElement("a"), {
+    rel: "noopener noreferrer",
+    href: href,
+  }).click();
+}
+
 export function ReleaseDownloadButton({
   release,
   buttonText,
@@ -198,7 +205,7 @@ export function ReleaseDownloadButton({
         css={buttonStyling}
         bordered={bordered}
       >
-        {isNightly ? <GiBrickWall size={16} /> : null}
+        {isNightly ? <IoIosCloudyNight size={22} /> : <GiBrickWall size={16} />}
         &nbsp;
         {buttonText}
       </Dropdown.Button>
@@ -206,7 +213,7 @@ export function ReleaseDownloadButton({
         color={isNightly ? "warning" : "primary"}
         aria-label="Actions"
         css={{ $$dropdownMenuWidth: "100%" }}
-        // Removed onAction handler to avoid extra clickable modifications
+        onAction={(assetUrl) => openAssetLink(assetUrl)}
       >
         <Dropdown.Section
           title={

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -40,7 +40,7 @@ function getOSIcon(os, fillColor) {
   }
 }
 
-  // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
+// Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
 function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
   if (!assets) {
     return [];

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -78,8 +78,6 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     } else if (os === "macos") {
       displayName = `Archive`;
-    } else {
-      displayName = `${displayName}`; // Keep the original display name
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -76,8 +76,6 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
         displayName = "AppImage";
       } else if (asset.additionalTags.includes("flatpak")) {
         displayName = "Flatpak";
-      } else {
-        displayName = "Linux"; // Default to "Linux" if no recognized tags
       }
     } else if (os === "macos") {
       displayName = "Download";

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -71,13 +71,9 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
     if (os === "windows") {
       displayName = "Download";
     } else if (os === "linux") {
-      // Check for Flatpak or AppImage tags
+      // Check for Flatpak or AppImage tags which will make Appimage - x64 Qt and Flatpak - x64 Qt and no way to seemingly fix the regular way
       if (asset.additionalTags.includes("appimage")) {
-        // Appimage gets shown instead due to problems with the tags, so strip it and append it
-        displayName =
-          "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage"
-        displayName = displayName.replace("image", ""); // Strip "image"
-        displayName = displayName + "Image"; // Append "Image"
+        displayName = "App" + displayName.charAt(3).toUpperCase() + displayName.slice(4); // Convert "Appimage" to "AppImage" because tags failing to uppercase it
       } else if (asset.additionalTags.includes("flatpak")) {
         displayName = "Flatpak";
       }

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -69,17 +69,19 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 
     // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
-      displayName = `Exe - x64 - Qt`;
+      displayName = `7z Archived Exe - x64 - Qt`;
     } else if (os === "linux") {
       if (asset.additionalTags.includes("flatpak")) {
         displayName = `Flatpak - x64 - Qt`;
       } else if (asset.additionalTags.includes("appimage")) {
         displayName = `AppImage - x64 - Qt`;
+      } else {
+        displayName = `x64 - Qt`;
       }
     } else if (os === "macos") {
-      displayName = `App - x64 - Qt`;
+      displayName = `xz Archived App - x64 - Qt`;
     } else {
-      displayName = `Unknown - x64 - Qt`; // Fallback for other OS
+      displayName = `${os.charAt(0).toUpperCase() + os.slice(1)} - x64 - Qt`;
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -67,7 +67,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
       }
     }
 
-// Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
+    // Generate a more dynamic displayName based on asset properties, following the format of package type - Bits(64) - GUI Widget (Qt)
     if (os === "windows") {
       displayName = `Exe - ${displayName}`;
     } else if (os === "linux") {

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -190,7 +190,7 @@ export function ReleaseDownloadButton({
         )
       );
     }
-  }, [release, isNightly]);
+  }, [release]);
 
   // Render the dropdown button and menu
   return (

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -66,15 +66,15 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
 
     // Generate a more dynamic displayName based on asset properties
     if (os === "windows") {
-      displayName = `Exe - ${os} - ${displayName}`;
+      displayName = `Exe - ${displayName}`;
     } else if (os === "linux") {
       if (asset.additionalTags.includes("appimage")) {
-        displayName = `AppImage - ${os} - ${displayName}`;
+        displayName = `AppImage - ${displayName}`;
       } else if (asset.additionalTags.includes("flatpak")) {
-        displayName = `Flatpak - ${os} - ${displayName}`;
+        displayName = `Flatpak - ${displayName}`;
       }
     } else if (os === "macos") {
-      displayName = `App.tar - ${os} - ${displayName}`;
+      displayName = `App - ${displayName}`;
     }
 
     items.push(

--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -75,8 +75,6 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
         displayName = `Flatpak - x64 - Qt`;
       } else if (asset.additionalTags.includes("appimage")) {
         displayName = `AppImage - x64 - Qt`;
-      } else {
-        displayName = `Linux - x64 - Qt`;
       }
     } else if (os === "macos") {
       displayName = `App - x64 - Qt`;


### PR DESCRIPTION
It looks off compared to the Linux side that looks cleaner when you download releases on pcsx2.net. Revising from
![image](https://github.com/PCSX2/pcsx2-net-www/assets/24227051/3924c7b2-6aff-4041-b911-f9c4ca3f163c)

into 

![image](https://github.com/PCSX2/pcsx2-net-www/assets/24227051/9c5b0c0f-3b44-4141-b274-c3426033124a)
