### PR TITLE
Fix broken link on Downloads page

### DIFF
--- a/src/pages/downloads/index.js
+++ b/src/pages/downloads/index.js
@@ -283,9 +283,7 @@ export default function Downloads() {
                 <Grid xs={12}>
                   <p>
                     For help using these releases,{" "}
-                    <a href="/docs/usage/setup/">
-                      see the following article.
-                    </a>
+                    <a href="/docs/usage/setup/">see the following article.</a>
                   </p>
                 </Grid>
                 <Grid xs={12} css={{ mt: "2em" }}>

--- a/src/pages/downloads/index.js
+++ b/src/pages/downloads/index.js
@@ -283,7 +283,7 @@ export default function Downloads() {
                 <Grid xs={12}>
                   <p>
                     For help using these releases,{" "}
-                    <a href="/docs/usage/nightly-setup/">
+                    <a href="/docs/usage/setup/">
                       see the following article.
                     </a>
                   </p>


### PR DESCRIPTION
Forgot to change it when we moved the docs link