### PR TITLE
BlogPostItem: add titleImage styling in prevision of 2.0

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -262,6 +262,7 @@ table td {
   margin-right: auto;
   background-size: cover;
   text-shadow: 0px 5px 4px #000;
+  margin-bottom: 1cm;
 }
 
 .blog-post-page header > h1 {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -248,3 +248,23 @@ table td {
 .nextui-table-hidden-row {
   border: none;
 }
+
+.header-blog {
+  margin: 0;
+  margin-right: 0px;
+  margin-left: 0px;
+  background: #eee;
+  background-image: none;
+  background-size: auto;
+  padding: 1em;
+  border-radius: 1em;
+  margin-left: auto;
+  margin-right: auto;
+  background-size: cover;
+  text-shadow: 0px 5px 4px #000;
+}
+
+.blog-post-page header > h1 {
+  text-shadow: none;
+  filter: drop-shadow(0px 5px 4px #000);
+}

--- a/src/theme/BlogPostItem/Header/index.js
+++ b/src/theme/BlogPostItem/Header/index.js
@@ -1,0 +1,27 @@
+import React from "react";
+import BlogPostItemHeaderTitle from "@theme-original/BlogPostItem/Header/Title";
+import BlogPostItemHeaderInfo from "@theme-original/BlogPostItem/Header/Info";
+import BlogPostItemHeaderAuthors from "@theme-original/BlogPostItem/Header/Authors";
+import { useBlogPost } from "@docusaurus/theme-common/internal";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+
+export default function BlogPostItemHeader() {
+  const { metadata } = useBlogPost();
+  const image = useBaseUrl(metadata.frontMatter.titleImage);
+
+  let bgStyle = {};
+  let classBlog = "";
+  if (metadata.frontMatter.titleImage) {
+    classBlog = "header-blog";
+    bgStyle = {
+      backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url("${image}")`,
+    };
+  }
+  return (
+    <header className={classBlog} style={bgStyle}>
+      <BlogPostItemHeaderTitle />
+      <BlogPostItemHeaderInfo />
+      <BlogPostItemHeaderAuthors />
+    </header>
+  );
+}


### PR DESCRIPTION
## Small design improvement for 2.0:

Adds a titleImage property to MDX that allows the writer to have a title background on the post, as seen below.
If unused, reverts to the previous styling.
![image](https://github.com/PCSX2/pcsx2-net-www/assets/6375438/9ba1c5e8-27b9-4ff4-a7de-9e970a2c1e8c)

We should:
- [x] Look into the styling of authors name when using a titleImage for improved readability
   (Added some drop shadow for styling)


## How to test:

Add a `titleImage` to any blog post metadata, pointing to the `static/img` folder