### PR TITLE
misc white theme title fixes

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -265,7 +265,7 @@ table td {
   margin-bottom: 1cm;
 }
 
-.blog-post-page header > h1 {
+.header-blog h1 {
   text-shadow: none;
   filter: drop-shadow(0px 5px 4px #000);
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -269,3 +269,11 @@ table td {
   text-shadow: none;
   filter: drop-shadow(0px 5px 4px #000);
 }
+
+.header-blog a {
+  color: rgb(89, 197, 255);
+}
+
+.header-blog .margin-vert--md {
+  color: rgb(227, 227, 227);
+}


### PR DESCRIPTION
This fixes a few issues I picked up on when using the white theme with the new titleImage styling


before:
<img width="1256" alt="Capture d’écran 2024-02-04 à 10 15 27" src="https://github.com/PCSX2/pcsx2-net-www/assets/6375438/8ff0335e-2422-40d8-b495-f903ed2ebe32">
<img width="1215" alt="Capture d’écran 2024-02-04 à 10 15 42" src="https://github.com/PCSX2/pcsx2-net-www/assets/6375438/6e537f76-fe95-4773-a01c-20872bb57e67">

now:
<img width="1273" alt="Capture d’écran 2024-02-04 à 10 16 02" src="https://github.com/PCSX2/pcsx2-net-www/assets/6375438/d6a82b19-1422-48ad-9d3f-ba2e82100fe5">
<img width="1427" alt="Capture d’écran 2024-02-04 à 10 16 20" src="https://github.com/PCSX2/pcsx2-net-www/assets/6375438/72c1e0bc-5f1b-4e2c-8edb-829a9fc2a54c">




NB: might be interesting to check whether we can "invert" the titleImage card like the homepage animation to fully conform to the white theme...