### PR TITLE
gitignore: ignore autogenerated yarn deps files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Dependencies
 /node_modules
+package-lock.json*
+package.json*
+yarn.lock*
 
 # Production
 /build


### PR DESCRIPTION
This PR cleans up useless yarn.lock and package.json files as they are automatically generated when you do `npm install`