### PR TITLE
Site: Add Dark Reader compatibility

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,7 +136,10 @@ const config = {
         respectPrefersColorScheme: true,
       },
       image: "img/logo.webp",
-      metadata: [{ name: "twitter:card", content: "summary" }],
+      metadata: [
+        { name: "twitter:card", content: "summary" },
+        { name: "darkreader-lock" },
+      ],
       navbar: {
         title: "PCSX2",
         logo: {


### PR DESCRIPTION
Make Dark Reader automatically disables itself on the main PCSX2 site.

Fixes #282 