### PR TITLE
Redirects: Create pcsx2.net/discord

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,7 +46,7 @@ params:
     - name: Discord
       icon: fab fa-discord
       weight: 1
-      url: "https://discord.com/invite/TCz3t9k"
+      url: "https://pcsx2.net/discord"
     - name: Github
       icon: fab fa-github
       weight: 2
@@ -130,7 +130,7 @@ languages:
   #         url: /about
   #       - name: Discord
   #         weight: 6
-  #         url: 'https://discord.com/invite/TCz3t9k'
+  #         url: 'https://pcsx2.net/discord'
   #         pre: fa fa-discord
   #       - name: Github
   #         weight: 7

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,4 @@ sidebar_position: 1
 
 Here you will find various documentation related to the PCSX2 project, intended for both general user and technical audiences.
 
-If this article does not help solve your problem, reach out in the [Discord](https://discord.com/invite/TCz3t9k) channel or the [forum](https://forums.pcsx2.net/).
+If this article does not help solve your problem, reach out in the [Discord](https://pcsx2.net/discord) channel or the [forum](https://forums.pcsx2.net/).

--- a/docs/troubleshooting/identify.md
+++ b/docs/troubleshooting/identify.md
@@ -73,4 +73,4 @@ It helps to write down the PCSX2 versions you're testing as you go, and note whe
 
 ## Reach out for help
 
-After you've collected all the report materials, consider reaching out in either the respective [Discord](https://discord.com/invite/TCz3t9k) channel or the [forum](https://forums.pcsx2.net/) for further assistance.
+After you've collected all the report materials, consider reaching out in either the respective [Discord](https://www.pcsx2.net/discord) channel or the [forum](https://forums.pcsx2.net/) for further assistance.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,7 +186,7 @@ const config = {
           },
           { to: "https://wiki.pcsx2.net/", label: "Wiki", position: "right" },
           {
-            href: "https://discord.com/invite/TCz3t9k",
+            href: "https://pcsx2.net/discord",
             position: "right",
             className: "header-discord-link",
             "aria-label": "Discord",
@@ -279,7 +279,7 @@ const config = {
             items: [
               {
                 label: "Discord",
-                href: "https://discord.com/invite/TCz3t9k",
+                href: "https://pcsx2.net/discord",
               },
               {
                 label: "Forums",

--- a/redirects.js
+++ b/redirects.js
@@ -9,6 +9,10 @@ const redirects = [
     ],
   },
   {
+    to: "https://discord.com/invite/TCz3t9k",
+    from: "/discord",
+  },
+  {
     to: "/blog/2021/aethersx2-brings-pcsx2-to-mobile",
     from: "/301-aethersx2-pcsx2-mobile",
   },


### PR DESCRIPTION
Credit to @GovanifY for giving me the idea and to @kamfretoz for pointing out that there's an easy way to do redirects. :smile: 

This makes it so that 1) we and anyone else can easily reproduce the link from memory because it's not a string of random characters, and importantly 2) if the invite link ever does change, we don't ever need to go cleaning things up except to change it in the `redirects.js` file.