### PR TITLE
styling: fix download link colors when on light-mode

### DIFF
--- a/src/components/ReleaseDownloadButton/index.js
+++ b/src/components/ReleaseDownloadButton/index.js
@@ -115,7 +115,7 @@ function generateDropdownItems(release, os, assets, textRemovals, isNightly) {
         key={asset.url}
         description={release.version}
         startContent={getOSIcon(os, fillColor)}
-        className="no-underline hover:no-underline text-white"
+        className="no-underline hover:no-underline dark:text-white text-black"
       >
         {displayName}
       </DropdownItem>,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9f94ac50-3241-4e4f-ab81-4a26bb3b5955)
![image](https://github.com/user-attachments/assets/75c58494-01fd-4859-b72c-6fc4ecf5bc13)

Fixes #388 