### PR TITLE
typo: make sure the wiki link sends the user to it and not the forums...

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -274,7 +274,7 @@ const config = {
               },
               {
                 label: "Wiki",
-                href: "https://forums.pcsx2.net/",
+                href: "https://wiki.pcsx2.net/",
               },
               {
                 label: "Status",


### PR DESCRIPTION
how did we not notice until now