### PR TITLE
DownloadTable: make totalTable stateful and fix NaN bug

### DIFF
--- a/src/components/DownloadTable/index.js
+++ b/src/components/DownloadTable/index.js
@@ -25,12 +25,19 @@ export function DownloadTable({
   const [tableLoadingState, setTableLoadingState] = useState("idle");
   const [tablePage, setTablePage] = useState(1);
   const [selectedVersion, setSelectedVersion] = useState(undefined);
+  const [totalPages, setTotalPages] = useState(0);
 
   const rowsPerPage = 10;
 
   useEffect(() => {
     setTableData(initialTableData);
   }, [initialTableData]);
+
+  useEffect(() => {
+    if (tableData?.pageInfo?.total && pageSize) {
+      setTotalPages(Math.ceil(tableData.pageInfo.total / pageSize));
+    }
+  }, [tableData, pageSize]);
 
   const tableRows = React.useMemo(() => {
     const start = (tablePage - 1) * rowsPerPage;
@@ -65,7 +72,7 @@ export function DownloadTable({
                 showControls
                 showShadow
                 page={tablePage}
-                total={Math.ceil(tableData?.pageInfo?.total / pageSize)}
+                total={totalPages}
                 onChange={async (page) => {
                   setTableLoadingState("loadingMore");
                   page = page - 1;


### PR DESCRIPTION
Total needs to be stateful in order to tell the Pagination element to update its presentation, otherwise it will create arrows where it shouldn't which might lead to jumping into undefined territory (literally)

This fixes https://github.com/PCSX2/pcsx2-net-www/issues/401