### PR TITLE
config: add banner for stop killing games

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,13 +137,13 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      // announcementBar: {
-      //   id: "announcementBar-1", // Increment on change (2.0 was 0, next announcement should be 1)
-      //   content: `<a class="no-underline font-medium" href="/blog/2024/pcsx2-2-release/">PCSX2 2.0 is finally here, check out our new blog post!</a>`,
-      //   backgroundColor: "#4765c8",
-      //   textColor: "#fafbfc",
-      //   isCloseable: true,
-      // },
+      announcementBar: {
+        id: "announcementBar-1", // Increment on change (2.0 was 0, next announcement should be 1)
+        content: `<a class="no-underline font-medium" href="https://eci.ec.europa.eu/045/public/">If you are a EU citizen, please consider signing the Stop Killing Games citizens initiative !</a>`,
+        backgroundColor: "#4765c8",
+        textColor: "#fafbfc",
+        isCloseable: true,
+      },
       algolia: {
         // The application ID provided by Algolia
         appId: "TR9JNR7TSP",


### PR DESCRIPTION
This is an initiative for the preservation of video games, available here:

https://eci.ec.europa.eu/045/public/#/screen/home

Dolphin already links to it and now that the ban on conversion therapy (yay!) passed the threshold I got reminded of this one, let's try to give it a push with our reach :)