### PR TITLE
Docs: Add security warning to the General Information page

### DIFF
--- a/docs/post/general.md
+++ b/docs/post/general.md
@@ -8,6 +8,10 @@ sidebar_position: 1
 
 General information in regards to PCSX2 features.
 
+:::danger
+**Do not run untrusted programs in PCSX2. It is not a sandbox and cannot protect your computer from malicious software.**
+:::
+
 ## Renderer options
 
 :::caution


### PR DESCRIPTION
Adds some text to the General Information page warning against running untrusted code.

![Screenshot_20250624_182702](https://github.com/user-attachments/assets/5462dacd-884b-4cc9-839f-c095bec65b6a)

More discussion here: https://github.com/PCSX2/pcsx2/pull/12900