### PR TITLE
Blog: Fix accidental copy-paste placeholder which was never removed

### DIFF
--- a/blog/2025/pcsx2-2.4_2.2/index.mdx
+++ b/blog/2025/pcsx2-2.4_2.2/index.mdx
@@ -210,8 +210,6 @@ The right answer to "What does [SDL](https://en.wikipedia.org/wiki/Simple_Direct
 
 ### Various Smaller Improvements in 2.4
 
-Before we move on to 2.4 and the big changes it brought, we want to stop and spotlight the smaller work that goes into making PCSX2 a polished experience. Below are just a few among hundreds, and we're grateful for every single one.
-
 - [#12157](https://github.com/PCSX2/pcsx2/pull/12157) – Contributor Florin9doi adds support for the MemCard PRO2.
 - [#12494](https://github.com/PCSX2/pcsx2/pull/12494) – First-time contributor recursean adds a adds a nice improvement to the debugger which adds column titles to Disassembly view.
 - [#12593](https://github.com/PCSX2/pcsx2/pull/12593) – Contributor TheTechnician27 fixed an issue with global settings overriding per-game settings in terms of audio.


### PR DESCRIPTION
Text was never properly removed from the blog before it was pushed to prod.