### PR TITLE
Blog: Fix incorrect reference to 2.2 at start of 2.4 section

### DIFF
--- a/blog/2025/pcsx2-2.4_2.2/index.mdx
+++ b/blog/2025/pcsx2-2.4_2.2/index.mdx
@@ -98,7 +98,7 @@ Before we move on to 2.4 and the big changes it brought, we want to stop and spo
 
 ## PCSX2 2.4.0
 
-After 2.0, the 2.2 development cycle let us catch our breath and – for the most part – focus on finer details. Brewing under the surface, though, were fresh ideas and the zeal to bring them to life. We all wanted to get back to innovating, so that's what we did. The 2.2 development cycles comes with many performance improvements and new features.
+After 2.0, the 2.2 development cycle had let us catch our breath and – for the most part – focus on finer details. Brewing under the surface, though, were fresh ideas and the zeal to bring them to life. We all wanted to get back to innovating, so that's what we did. The 2.4 development cycle comes with many performance improvements and new features.
 
 <PCSX2PRLink authors="refractionpcsx2" prNums="11461">
   ### RT in RT Support


### PR DESCRIPTION
Pretty sure the last version number at the start of the 2.4.0 section is meant to be 2.4 instead of 2.2. Also added "had" so 2.2 is referred to more in the past tense, and de-pluralised the 2.4 development cycle.