### PR TITLE
Banner: Remove SDVG EU initiative announcement as petition is closed

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,13 +137,13 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      announcementBar: {
-        id: "announcementBar-1", // Increment on change (2.0 was 0, next announcement should be 1)
-        content: `<a class="no-underline font-medium" href="https://eci.ec.europa.eu/045/public/">If you are an EU citizen, please consider signing the Stop Killing Games citizens' initiative!</a>`,
-        backgroundColor: "#4765c8",
-        textColor: "#fafbfc",
-        isCloseable: true,
-      },
+      // announcementBar: {
+      //   id: "announcementBar-1", // Increment on change (SKG announcement was 1, next announcement should be 2)
+      //   content: `<a class="no-underline font-medium" href=""></a>`,
+      //   backgroundColor: "#4765c8",
+      //   textColor: "#fafbfc",
+      //   isCloseable: true,
+      // },
       algolia: {
         // The application ID provided by Algolia
         appId: "TR9JNR7TSP",


### PR DESCRIPTION
Stop Destroying Videogames EU initiative is no longer active and thus users cannot sign the petition. No need for the current banner anymore.