### PR TITLE
Downloads: Cleanup and make Stable and Nightly builds more symmetrical

### DIFF
--- a/src/components/DownloadTable/index.js
+++ b/src/components/DownloadTable/index.js
@@ -71,6 +71,7 @@ export function DownloadTable({
                 isCompact
                 showControls
                 showShadow
+                color={tableType === "nightly" ? "warning" : "primary"}
                 page={tablePage}
                 total={totalPages}
                 onChange={async (page) => {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -404,6 +404,25 @@ table td {
   font-weight: 700;
 }
 
+.h1-icon {
+  fontsize: "1em";
+  verticalalign: "middle";
+}
+
+.h1-icon-spacer {
+  fontsize: "0.5em";
+  verticalalign: "middle";
+  marginleft: "0.5em";
+}
+
+.stable-blue {
+  color: "#4b7cd7";
+}
+
+.nightly-orange {
+  color: "#b58d05";
+}
+
 .imgCompareContainer {
   display: inline-block;
   line-height: 0;

--- a/src/pages/downloads/index.js
+++ b/src/pages/downloads/index.js
@@ -7,6 +7,8 @@ import { DownloadTable } from "../../components/DownloadTable";
 import { getLatestRelease } from "../../components/ReleaseDownloadButton";
 import Head from "@docusaurus/Head";
 import ReactMarkdown from "react-markdown";
+import { IoIosCloudyNight } from "react-icons/io";
+import { GiBrickWall } from "react-icons/gi";
 import { GoogleAd } from "../../components/GoogleAd";
 import useIsBrowser from "@docusaurus/useIsBrowser";
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
@@ -18,7 +20,7 @@ const releaseTableColumns = [
   },
   {
     key: "releaseInfo",
-    label: "INFO",
+    label: "RELEASE DATE",
   },
 ];
 
@@ -167,7 +169,7 @@ export default function Downloads() {
   return (
     <Layout
       title="Downloads"
-      description="The official source for the latest stable and nightly builds (aka dev builds) for PCSX2 on all supported platforms"
+      description="The official source for the latest stable and nightly builds of PCSX2 on all supported platforms"
     >
       <Head>
         <meta property="og:description" content="" />
@@ -185,6 +187,8 @@ export default function Downloads() {
                 <div>
                   <h1 className="bg-clip-text text-transparent bg-gradient-to-b from-[#5099ff] to-[#465eae]">
                     Stable Releases
+                    <span className="h1-icon-spacer" />
+                    <GiBrickWall className="h1-icon stable-blue" />
                   </h1>
                 </div>
                 {apiErrorMsg !== undefined && (
@@ -200,7 +204,7 @@ export default function Downloads() {
                             href="https://github.com/PCSX2/pcsx2/releases"
                             target="_blank"
                             rel="noreferrer"
-                            className="text-blue-500 hover:underline"
+                            className="stable-blue hover:underline"
                           >
                             GitHub
                           </a>
@@ -221,7 +225,7 @@ export default function Downloads() {
                 )}
                 <div>
                   <p>
-                    Stable releases are infrequent but well tested compared to
+                    Stable releases are infrequent but well-tested compared to
                     the nightly releases.
                   </p>
                 </div>
@@ -229,18 +233,9 @@ export default function Downloads() {
                   <p>
                     If you need help using the emulator,{" "}
                     <a href="/docs/" className="text-blue-500 hover:underline">
-                      see the following article.
+                      see the documentation.
                     </a>
                   </p>
-                </div>
-                <div>
-                  <Admonition type="caution">
-                    <p>
-                      If you are having trouble downloading, try disabling your
-                      pop-up blocker (e.g. Poper Blocker) as they are known to
-                      cause problems with our download links.
-                    </p>
-                  </Admonition>
                 </div>
                 <div className="mt-8">
                   <ReleaseDownloadButton
@@ -307,6 +302,8 @@ export default function Downloads() {
                 <div>
                   <h1 className="bg-clip-text text-transparent bg-gradient-to-b to-[#777500] from-[#f2a40a]">
                     Nightly Releases
+                    <span className="h1-icon-spacer" />
+                    <IoIosCloudyNight className="h1-icon nightly-orange" />
                   </h1>
                 </div>
                 {apiErrorMsg !== undefined && (
@@ -343,9 +340,16 @@ export default function Downloads() {
                 )}
                 <div>
                   <p>
-                    There is a new nightly release anytime a change is made, so
-                    you are getting the latest and greatest (but sometimes
-                    buggy) experience.
+                    Nightly releases always have the newest features but are
+                    less tested than the stable releases.
+                  </p>
+                </div>
+                <div>
+                  <p>
+                    If you need help using the emulator,{" "}
+                    <a href="/docs/" className="nightly-orange hover:underline">
+                      see the documentation.
+                    </a>
                   </p>
                 </div>
                 <div className="mt-8">


### PR DESCRIPTION
A bit of cleanup on the downloads page – mostly making the two columns symmetrical:

* Gave both the Stable and Nightly builds their respective icon next to their header.
  * The color of this is the exact median between the two extremes of their gradients.
  * This just gives a nice bit of extra visual recognition.
* Changed description text for nightlies:
  * From: "There is a new nightly release anytime a change is made, so you are getting the latest and greatest (but sometimes buggy) experience."
  * To: "Nightly releases always have the newest features but are less tested than the stable releases."
  * This conveys the tradeoffs of the nightly versions more effectively ("newest features" versus "more updates"), elegantly (no parenthetical aside), succinctly (...), symmetrically (compare to Stable description), and accurately ("but sometimes buggy" applies just as well if not moreso to our stables for how often we fix bugs.)
* Changes "see the following article" to "see the documentation".
  * We link the user to the landing page of the docs, which are a tree of nearly two dozen categorized articles.
* Removes the warning: "If you are having trouble downloading, try disabling your pop-up blocker (e.g. Poper Blocker) as they are known to cause problems with our download links."
  * Poper Blocker is spyware, but I can give it this one singular piece of credit: it works here now.
  * According to Tellow, this is potentially explained by us changing these download links to be actual links.
* Makes the color for the Nightly hypertext for "see the documentation" match the Nightly column color.
* Changes "INFO" column header in previous builds to "RELEASE DATE".
  * This is literally the only info that column header provides.
  * Maybe in the future it could have the author name as a column?
* Makes the color for the Nightly pagination highlight match the Nightly column color.

All of this has the nice side effect (this was not the end goal, but this is arguably what end users would notice most) of balancing out the two sides vertically.

#### PR:

<img width="1920" height="1080" alt="Example PR" src="https://github.com/user-attachments/assets/0e649d04-245a-489e-9e52-ba5b26bab60e" />

---
#### Production:

<img width="1920" height="1080" alt="Example 1 Current" src="https://github.com/user-attachments/assets/fba58622-4e3b-41ee-a0f3-1f1418f30b09" />

<img width="1920" height="1080" alt="Example 2 Current" src="https://github.com/user-attachments/assets/df966aa8-facc-43be-a4b7-9655f4821db9" />
