### PR TITLE
Build: Add Liberapay and fix "last updated by" on pages

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,4 @@
 # These are supported funding model platforms
 
 github: [PCSX2]
+liberapay: PCSX2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
* Adds Liberapay to the `FUNDING.yml` like on the main repo.
* Adds `with: fetch-depth: 0` to the repo checkout.
  * Therefore checks out the entire history.
  * So that the "last edited by" credit is correct.
    * Currently, the last person to submit any change to the repo will get the blame for every page.
  * Fix described [here](https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951) and recommended by @xTVaser.