### PR TITLE
Docs: Add icons to tab headers in setup docs

### DIFF
--- a/docs/setup/bios.md
+++ b/docs/setup/bios.md
@@ -9,6 +9,10 @@ toc: true
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { BiSolidCard } from "react-icons/bi";
+import { BsWindows, BsApple, BsUsbSymbol } from "react-icons/bs";
+import { FaLinux, FaCompactDisc, FaTerminal, FaNetworkWired } from "react-icons/fa";
+import { SiKde, SiGnome, SiDebian, SiFedora, SiArchlinux, SiSuse, SiNixos } from "react-icons/si";
 
 This page helps you dump the BIOS files from your PlayStation 2 console.
 
@@ -68,7 +72,7 @@ alt="A mostly black screen reads biosdrain - revision v2.1.1 in the upper-right.
 FreeMcBoot and FreeDVDBoot bundle a generally useful homebrew program, uLaunchELF,[^wLaunchELF] that lets you browse memory cards, DVDs, and USB drives connected to your PS2 and run programs from them.
 
 <Tabs queryString="softmod">
- <TabItem value="freemcboot" label="Using FreeMcBoot" default>
+  <TabItem value="freemcboot" label={<span className="tab_header_with_icon"><BiSolidCard />Using FreeMcBoot</span>} default>
 
 1. Insert the FreeMcBoot memory card into Memory Card Slot 1.
 2. Make sure the disc tray is empty.
@@ -76,7 +80,7 @@ FreeMcBoot and FreeDVDBoot bundle a generally useful homebrew program, uLaunchEL
 4. Select uLaunchELF from the menu.
 
  </TabItem>
- <TabItem value="freedvdboot" label="Using FreeDVDBoot">
+ <TabItem value="freedvdboot" label={<span className="tab_header_with_icon"><FaCompactDisc />Using FreeDVDBoot</span>}>
 
 1. Download the ISO which corresponds to your PS2 model from [FreeDVDBoot's GitHub repository](https://github.com/CTurt/FreeDVDBoot/tree/master/PREBUILT%20ISOs).
 2. Burn the ISO to a DVD.
@@ -96,7 +100,7 @@ FreeMcBoot and FreeDVDBoot bundle a generally useful homebrew program, uLaunchEL
 biosdrain supports dumping both to a USB flash drive and via HOST through ps2link. We recommend USB for most users. If your console does not have networking support, you cannot use the ps2link method.
 
 <Tabs queryString="medium">
- <TabItem value="usb" label="USB Flash Drive" default>
+ <TabItem value="usb" label={<span className="tab_header_with_icon"><BsUsbSymbol />USB Flash Drive</span>} default>
 
 :::note[Note – USB issues]
 
@@ -110,7 +114,7 @@ To use the USB method, you will need a USB flash drive which is partitioned as [
 <details>
 <summary>Expand to see a guide on formatting your flash drive</summary>
 <Tabs queryString="os">
-<TabItem value="windows" label="Windows" default>
+<TabItem value="windows" label={<span className="tab_header_with_icon"><BsWindows />Windows</span>} default>
 On Windows, we recommend the free and open-source tool Rufus.
 
 :::danger[Danger – Data loss]
@@ -139,7 +143,7 @@ alt="A Rufus window after formatting a USB flash drive. The Drive Properties sec
 />
 
 </TabItem>
-<TabItem value="macos" label="macOS">
+<TabItem value="macos" label={<span className="tab_header_with_icon"><BsApple />macOS</span>}>
 
 On macOS, we recommend the built-in Disk Utility application.
 
@@ -171,7 +175,7 @@ alt="A window in Disk Utility asking if the user wishes to erase their flash dri
 />
 
 </TabItem>
-<TabItem value="linux" label="Linux">
+<TabItem value="linux" label={<span className="tab_header_with_icon"><FaLinux />Linux</span>}>
 On Linux, we recommend KDE Partition Manager or GNOME Disks.
 
 :::note[Note – Command line]
@@ -181,7 +185,7 @@ On Linux, we recommend KDE Partition Manager or GNOME Disks.
   :::
 
 <Tabs queryString="partition-tool">
-<TabItem value="kde" label="KDE Partition Manager" default>
+<TabItem value="kde" label={<span className="tab_header_with_icon"><SiKde />KDE Partition Manager</span>} default>
 KDE Partition Manager is an application built into KDE Plasma for managing storage devices.
 
 :::danger[Danger – Data loss]
@@ -195,29 +199,29 @@ KDE Partition Manager is a powerful tool which can easily cause permanent data l
 
 :::tip[Tip – Installing KDE Partition Manager]
 <Tabs queryString="distro">
-<TabItem value="debian" label="Debian" default>
+<TabItem value="debian" label={<span className="tab_header_with_icon"><SiDebian />Debian</span>} default>
 
 ```bash
 sudo apt install partitionmanager
 ```
 
 </TabItem>
-<TabItem value="fedora" label="Fedora">
+<TabItem value="fedora" label={<span className="tab_header_with_icon"><SiFedora />Fedora</span>}>
 ```bash
 sudo dnf install partitionmanager
 ```
 </TabItem>
-<TabItem value="arch" label="Arch">
+<TabItem value="arch" label={<span className="tab_header_with_icon"><SiArchlinux />Arch</span>}>
 ```bash
 sudo pacman -S partitionmanager
 ```
 </TabItem>
-<TabItem value="suse" label="SUSE">
+<TabItem value="suse" label={<span className="tab_header_with_icon"><SiSuse />SUSE</span>}>
 ```bash
 sudo zypper install partitionmanager
 ```
 </TabItem>
-<TabItem value="nixos" label="NixOS">
+<TabItem value="nixos" label={<span className="tab_header_with_icon"><SiNixos />NixOS</span>}>
 - [MyNixOS page](https://mynixos.com/nixpkgs/package/kdePackages.partitionmanager)
 </TabItem>
 </Tabs>
@@ -247,7 +251,7 @@ src={require("./img/bios/kde_partition_manager.webp").default}
 alt="A window titled Apply Pending Operations is opened which asks, Do you really want to apply the pending operations listed below? and warns, This will permanently modify your disks. Two lines read, first, Create a new partition table (type: msdos) on /dev/sdd, and, second, Create a new partition (239.01 GiB, fat32) on /dev/sdd. At the bottom is an Apply Pending Operations button on the left and a Cancel button on the right."
 />
 </TabItem>
-<TabItem value="gnome" label="GNOME Disks">
+<TabItem value="gnome" label={<span className="tab_header_with_icon"><SiGnome />GNOME Disks</span>}>
 GNOME Disks is an application built into GNOME for managing storage devices.
 
 :::danger[Danger – Data loss]
@@ -262,27 +266,27 @@ GNOME Disks is a powerful tool which can easily cause permanent data loss if mis
 :::tip[Tip – Installing GNOME Disks]
 
 <Tabs queryString="distro">
-<TabItem value="debian" label="Debian" default>
+<TabItem value="debian" label={<span className="tab_header_with_icon"><SiDebian />Debian</span>} default>
 ```bash
 sudo apt install gnome-disk-utility
 ```
 </TabItem>
-<TabItem value="fedora" label="Fedora">
+<TabItem value="fedora" label={<span className="tab_header_with_icon"><SiFedora />Fedora</span>}>
 ```bash
 sudo dnf install gnome-disk-utility
 ```
 </TabItem>
-<TabItem value="arch" label="Arch">
+<TabItem value="arch" label={<span className="tab_header_with_icon"><SiArchlinux />Arch</span>}>
 ```bash
 sudo pacman -S gnome-disk-utility
 ```
 </TabItem>
-<TabItem value="suse" label="SUSE">
+<TabItem value="suse" label={<span className="tab_header_with_icon"><SiSuse />SUSE</span>}>
 ```bash
 sudo zypper install gnome-disk-utility
 ```
 </TabItem>
-<TabItem value="nixos" label="NixOS">
+<TabItem value="nixos" label={<span className="tab_header_with_icon"><SiNixos />NixOS</span>}>
 - [MyNixOS page](https://mynixos.com/nixpkgs/package/gnome-disk-utility)
 </TabItem>
 </Tabs>
@@ -326,7 +330,7 @@ alt="A LaunchELF v4.43a screen displaying file paths. The row for mass:/ is high
 />
 
 </TabItem>
-<TabItem value="ps2client" label="ps2client & ps2link">
+<TabItem value="ps2client" label={<span className="tab_header_with_icon"><FaTerminal />ps2client & ps2link</span>}>
 
 1. `cd` into the directory where you have `biosdrain.elf`.
 2. Run the command:
@@ -339,11 +343,12 @@ alt="A LaunchELF v4.43a screen displaying file paths. The row for mass:/ is high
 
 You should see files prefixed by your console model ID and ending in `.rom0`,`.rom1`,`.nvm`, etc., in the root directory of `host`.
 
- </TabItem>
- <TabItem value="xlink" label="XLink & ps2link">
+</TabItem>
+<TabItem value="xlink" label={<span className="tab_header_with_icon"><FaNetworkWired />XLink & ps2link</span>}>
+
 1. Execute the `biosdrain.elf` with the user interface.
 2. biosdrain will automatically detect that the `host` device is present and dump your BIOS contents to the root directory of `host`.
-    - The root of `host` is usually where you have the biosdrain.elf file.
+   - The root of `host` is usually where you have the biosdrain.elf file.
 3. When biosdrain says "Finished Everything", the dumping process is finished.
 
 You should see files prefixed by your console model ID and ending in `.rom0`,`.rom1`,`.nvm`, etc., in the root directory of `host`.
@@ -355,19 +360,19 @@ You should see files prefixed by your console model ID and ending in `.rom0`,`.r
 Once you've finished dumping your PS2's BIOS, you're done and ready to use it for PCSX2. However, if you wish to first verify the integrity of the dump, the ReDump project maintains [a data file](https://redump.org/datfile/ps2-bios/) containing [hashes](https://en.wikipedia.org/wiki/Hash_function) for every PS2 BIOS version. To compute the SHA1 hash of the BIOS file you dumped:
 
 <Tabs queryString="os">
-<TabItem value="windows" label="Windows" default>
+<TabItem value="windows" label={<span className="tab_header_with_icon"><BsWindows />Windows</span>} default>
 On Windows, [use Get-FileHash in PowerShell](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-7.5):
   ```powershell
   Get-FileHash [path-to-file] -Algorithm SHA1
   ```
 </TabItem>
-<TabItem value="macos" label="macOS">
+<TabItem value="macos" label={<span className="tab_header_with_icon"><BsApple />macOS</span>}>
 On macOS, [use shasum in Terminal](https://linux.die.net/man/1/shasum):
   ```bash
   shasum [path-to-file]
   ```
 </TabItem>
-<TabItem value="linux" label="Linux">
+<TabItem value="linux" label={<span className="tab_header_with_icon"><FaLinux />Linux</span>}>
 On Linux, [use sha1sum in the shell](https://www.man7.org/linux/man-pages/man1/sha1sum.1.html):
   ```bash
   sha1sum [path-to-file]

--- a/docs/setup/discs.md
+++ b/docs/setup/discs.md
@@ -9,6 +9,9 @@ toc: true
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { BsWindows, BsApple } from "react-icons/bs";
+import { FaLinux } from "react-icons/fa";
+import { SiDebian, SiFedora, SiArchlinux, SiSuse, SiNixos, SiFlathub } from "react-icons/si";
 
 This page helps you create a backup of your physical game disc.
 
@@ -34,7 +37,7 @@ Although you can play games on PCSX2 directly from your disc, there are major ad
   :::
 
 <Tabs queryString="os">
-<TabItem value="windows" label="Windows" default>
+<TabItem value="windows" label={<span className="tab_header_with_icon"><BsWindows />Windows</span>} default>
 
 Disc dumping on Windows can be done using graphical tools like Media Preservation Frontend (MPF) and ImgBurn.
 
@@ -167,7 +170,7 @@ Your game will be in the destination folder you specified, and you can safely re
 </TabItem>
 </Tabs>
 </TabItem>
-<TabItem value="macos" label="macOS">
+<TabItem value="macos" label={<span className="tab_header_with_icon"><BsApple />macOS</span>}>
 
 Disc dumping on macOS can be done graphically using the built-in [Disk Utility](https://support.apple.com/guide/disk-utility/welcome/mac) application or in Terminal using shell commands like `dd` and `cdrdao`.
 
@@ -346,7 +349,7 @@ toc2cue [dump-name].toc [dump-name].cue
 </TabItem>
 </Tabs>
 </TabItem>
-<TabItem value="linux" label="Linux">
+<TabItem value="linux" label={<span className="tab_header_with_icon"><FaLinux />Linux</span>}>
 
 Disc dumping on Linux can be done using graphical tools like K3b and Brasero or shell commands like `dd` and `cdrdao`.
 
@@ -358,27 +361,27 @@ K3b is a free and open-source graphical utility for authoring optical media.
 :::tip[Tip – Installing k3b]
 
 <Tabs queryString="distro">
-<TabItem value="debian" label="Debian" default>
+<TabItem value="debian" label={<span className="tab_header_with_icon"><SiDebian />Debian</span>} default>
 ```bash
 sudo apt install k3b
 ```
 </TabItem>
-<TabItem value="fedora" label="Fedora">
+<TabItem value="fedora" label={<span className="tab_header_with_icon"><SiFedora />Fedora</span>}>
 ```bash
 sudo dnf install k3b
 ```
 </TabItem>
-<TabItem value="arch" label="Arch">
+<TabItem value="arch" label={<span className="tab_header_with_icon"><SiArchlinux />Arch</span>}>
 ```bash
 sudo pacman -S k3b
 ```
 </TabItem>
-<TabItem value="suse" label="SUSE">
+<TabItem value="suse" label={<span className="tab_header_with_icon"><SiSuse />SUSE</span>}>
 ```bash
 sudo zypper install k3b
 ```
 </TabItem>
-<TabItem value="nixos" label="NixOS">
+<TabItem value="nixos" label={<span className="tab_header_with_icon"><SiNixos />NixOS</span>}>
 ```bash
 programs.k3b.enable = true;
 ```
@@ -436,30 +439,30 @@ This method will only work on the GNOME desktop environment.
 :::tip[Tip – Installing Brasero]
 
 <Tabs queryString="distro">
-<TabItem value="debian" label="Debian" default>
+<TabItem value="debian" label={<span className="tab_header_with_icon"><SiDebian />Debian</span>} default>
 ```bash
 sudo apt install brasero
 ```
 </TabItem>
-<TabItem value="fedora" label="Fedora">
+<TabItem value="fedora" label={<span className="tab_header_with_icon"><SiFedora />Fedora</span>}>
 ```bash
 sudo dnf install brasero
 ```
 </TabItem>
-<TabItem value="arch" label="Arch">
+<TabItem value="arch" label={<span className="tab_header_with_icon"><SiArchlinux />Arch</span>}>
 ```bash
 sudo pacman -S brasero
 ```
 </TabItem>
-<TabItem value="suse" label="SUSE">
+<TabItem value="suse" label={<span className="tab_header_with_icon"><SiSuse />SUSE</span>}>
 ```bash
 sudo zypper install brasero
 ```
 </TabItem>
-<TabItem value="nixos" label="NixOS">
+<TabItem value="nixos" label={<span className="tab_header_with_icon"><SiNixos />NixOS</span>}>
 - [MyNixOS page](https://mynixos.com/nixpkgs/package/brasero)
 </TabItem>
-<TabItem value="flathub" label="Flathub">
+<TabItem value="flathub" label={<span className="tab_header_with_icon"><SiFlathub />Flathub</span>}>
 ```bash
 flatpak install org.gnome.Brasero
 ```

--- a/docs/setup/requirements.md
+++ b/docs/setup/requirements.md
@@ -9,6 +9,10 @@ toc: true
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { BsWindows, BsApple, BsLightningChargeFill } from "react-icons/bs";
+import { FaLinux } from "react-icons/fa";
+import { FaComputer, FaScaleBalanced } from "react-icons/fa6";
+import { GiTurtleShell } from "react-icons/gi"
 
 This page lists the system requirements to run PCSX2.
 
@@ -16,9 +20,9 @@ This page lists the system requirements to run PCSX2.
  <thead>
   <tr>
    <th scope="col"></th>
-   <th scope="col">Minimum</th>
-   <th scope="col">Moderate</th>
-   <th scope="col">Heavy</th>
+   <th scope="col">Minimum <GiTurtleShell className="table_header_icon"/></th>
+   <th scope="col">Moderate <FaScaleBalanced className="table_header_icon"/></th>
+   <th scope="col">Heavy <BsLightningChargeFill className="table_header_icon"/></th>
   </tr>
  </thead>
  <tbody>
@@ -132,9 +136,9 @@ Hardware requirements can vary drastically between games.
  <thead>
   <tr>
    <th scope="col"></th>
-   <th scope="col">Minimum</th>
-   <th scope="col">Moderate</th>
-   <th scope="col">Heavy</th>
+   <th scope="col">Minimum <GiTurtleShell className="table_header_icon"/></th>
+   <th scope="col">Moderate <FaScaleBalanced className="table_header_icon"/></th>
+   <th scope="col">Heavy <BsLightningChargeFill className="table_header_icon"/></th>
   </tr>
   </thead>
   <tbody>
@@ -156,23 +160,22 @@ Hardware requirements can vary drastically between games.
 ## Version Deprecations
 
 <Tabs queryString="deprecation">
-<TabItem value="general" label="General" default>
+<TabItem value="general" label={<span className="tab_header_with_icon"><FaComputer />General</span>} default>
 - Direct3D 9 support was dropped after stable release v1.4.0.
 - 32-bit support was dropped after stable release v1.6.0.
 
 </TabItem>
-<TabItem value="windows" label="Windows">
+<TabItem value="windows" label={<span className="tab_header_with_icon"><BsWindows />Windows</span>}>
 - Windows XP support was dropped after stable release v1.4.0.
 - Windows 7, Windows 8.0, and Windows 8.1 support was dropped after stable release v1.6.0.
 - Windows 10 21H1 and earlier support was dropped after stable release v2.4.0.
 
 </TabItem>
-<TabItem value="macos" label="macOS">
+<TabItem value="macos" label={<span className="tab_header_with_icon"><BsApple />macOS</span>}>
 - macOS 10.4 support was added and dropped during the nightly v1.7.X release cycle.
-<!--- TODO: macOS 11 and 12 support was dropped after stable release v2.4.0.-->
 
 </TabItem>
-<TabItem value="linux" label="Linux">
+<TabItem value="linux" label={<span className="tab_header_with_icon"><FaLinux />Linux</span>}>
 - Ubuntu 20.04 support was dropped after stable release v1.6.0.
 
 </TabItem>

--- a/docs/setup/running.md
+++ b/docs/setup/running.md
@@ -9,6 +9,12 @@ toc: true
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { AiFillPicture } from "react-icons/ai";
+import { BsWindows, BsApple } from "react-icons/bs";
+import { FaLinux, FaArchive } from "react-icons/fa";
+import { FaGear, FaTerminal } from "react-icons/fa6";
+import { MdInstallDesktop } from "react-icons/md";
+import { SiFlathub, SiKdeplasma, SiGnome, SiCinnamon } from "react-icons/si";
 
 This page helps you download and run PCSX2. PCSX2 is offered both as a Stable build which is updated every several months and as a Nightly build which is updated continually as PCSX2 is developed.
 
@@ -29,7 +35,7 @@ Use the Nightly build if you:
 ## Downloading and Running
 
 <Tabs queryString="os">
-<TabItem value="windows" label="Windows" default>
+<TabItem value="windows" label={<span className="tab_header_with_icon"><BsWindows />Windows</span>} default>
 
 PCSX2 on Windows can be used either as an installation (Stable only) or as a portable program (Stable and Nightly). The installer is more streamlined, while the portable version gives you more flexibility.
 
@@ -38,7 +44,7 @@ PCSX2 on Windows requires that you have the [latest x64 Visual C++ runtime](http
 :::
 
 <Tabs queryString="format">
-<TabItem value="installer" label="Installer" default>
+<TabItem value="installer" label={<span className="tab_header_with_icon"><MdInstallDesktop />Installer</span>} default>
 - Download the latest PCSX2 build for Windows from the [Download page](https://pcsx2.net/downloads).
 - Double-click the `.exe` file which you downloaded.
 - Windows will ask if you want to run this program. Click "Yes".
@@ -53,7 +59,7 @@ If you need to uninstall PCSX2, follow [this guide from Microsoft](https://suppo
 :::
 
 </TabItem>
-<TabItem value="portable" label="Portable">
+<TabItem value="portable" label={<span className="tab_header_with_icon"><FaArchive />Portable</span>}>
 
 - Download the latest PCSX2 build for Windows from the [Download page](https://pcsx2.net/downloads).
   - The portable version will be called "Download".
@@ -91,7 +97,7 @@ If you need to uninstall PCSX2, follow [this guide from Microsoft](https://suppo
 
 - PCSX2 requires additional [FFmpeg](https://en.wikipedia.org/wiki/FFmpeg) libraries if you wish to use its built-in video capture.
   - Download the FFmpeg Windows files [here](https://github.com/PCSX2/pcsx2-windows-dependencies/releases/tag/FFMPEG).
-  - Extract the contents of the `.zip` file.
+  - Extract the contents of the `.7z` file.
   - Place the extracted `.dll` files in the same folder as the PCSX2 `.exe` file.
 
 <details>
@@ -105,7 +111,7 @@ If you need to uninstall PCSX2, follow [this guide from Microsoft](https://suppo
         :::
 
 </TabItem>
-<TabItem value="macos" label="macOS">
+<TabItem value="macos" label={<span className="tab_header_with_icon"><BsApple />macOS</span>}>
 
 PCSX2 on macOS is distributed as an application bundle.
 
@@ -129,12 +135,12 @@ PCSX2's application name will change to reflect version updates. If you don't wa
 :::
 
 </TabItem>
-<TabItem value="linux" label="Linux">
+<TabItem value="linux" label={<span className="tab_header_with_icon"><FaLinux />Linux</span>}>
 
 PCSX2 on Linux is officially supported through an AppImage version and a Flatpak version.
 
 <Tabs queryString="format">
-<TabItem value="appimage" label="AppImage" default>
+<TabItem value="appimage" label={<span className="tab_header_with_icon"><FaGear />AppImage</span>} default>
 
 - Download the latest PCSX2 AppImage build from the [Download page](https://pcsx2.net/downloads).
 - You may need to make the AppImage file executable.
@@ -149,19 +155,19 @@ PCSX2 on Linux is officially supported through an AppImage version and a Flatpak
     <details>
       <summary>Expand to see examples in different file managers</summary>
       <Tabs queryString="environment">
-      <TabItem value="kde" label="KDE – Dolphin" default>
+      <TabItem value="kde" label={<span className="tab_header_with_icon"><SiKdeplasma />KDE – Dolphin</span>} default>
         <Image
         src={require("./img/running/mark_executable_kde.webp").default}
         alt="The KDE properties window for PCSX2.AppImage. The option Allow executing file as program is toggled on."
         />
       </TabItem>
-      <TabItem value="gnome" label="GNOME – Files">
+      <TabItem value="gnome" label={<span className="tab_header_with_icon"><SiGnome />GNOME – Files</span>}>
         <Image
         src={require("./img/running/mark_executable_gnome.webp").default}
         alt="The GNOME properties window for PCSX2.AppImage. The option Executable as Program is toggled on."
         />
       </TabItem>
-      <TabItem value="cinnamon" label="Cinnamon – Nemo">
+      <TabItem value="cinnamon" label={<span className="tab_header_with_icon"><SiCinnamon />Cinnamon – Nemo</span>}>
         <Image
         src={require("./img/running/mark_executable_cinnamon.webp").default}
         alt="The Cinnamon properties window for PCSX2.AppImage. The option Allow executing file as program is toggled on."
@@ -177,7 +183,7 @@ PCSX2 on Linux is officially supported through an AppImage version and a Flatpak
   />
 
 </TabItem>
-<TabItem value="flatpak" label="Flatpak">
+<TabItem value="flatpak" label={<span className="tab_header_with_icon"><SiFlathub />Flatpak</span>}>
 
 PCSX2 is available on [Flathub](https://flathub.org/apps/net.pcsx2.PCSX2)! You can install PCSX2 from Flathub through one of several compatible graphical package managers or through the shell.
 
@@ -188,7 +194,7 @@ PCSX2 is available on [Flathub](https://flathub.org/apps/net.pcsx2.PCSX2)! You c
   :::
 
 <Tabs queryString="interface">
-<TabItem value="graphical" label="Graphical" default>
+<TabItem value="graphical" label={<span className="tab_header_with_icon"><AiFillPicture />Graphical</span>} default>
 
 Many distributions and desktop environments have a graphical package manager which can install and update Flatpak applications. [These include](https://flatpak.org/setup/):
 
@@ -208,7 +214,7 @@ alt="The first page of the PCSX2 setup wizard on KDE Plasma 6, headlined, Welcom
 />
 
 </TabItem>
-<TabItem value="shell" label="Shell">
+<TabItem value="shell" label={<span className="tab_header_with_icon"><FaTerminal />Shell</span>}>
 
 In the terminal:
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -321,6 +321,12 @@ aside > div > nav.menu {
 
 /* Article CSS */
 
+/* Fix author name vertical alignment next to avatar image in Docusaurus blog posts */
+.avatar__name {
+  margin: auto;
+  position: absolute;
+}
+
 .blog-post-page header > h1 {
   background-image: linear-gradient(
     rgb(80, 153, 255) 25%,
@@ -465,8 +471,13 @@ table td {
   z-index: 2;
 }
 
-/* Fix author name vertical alignment next to avatar image in Docusaurus blog posts */
-.avatar__name {
-  margin: auto;
-  position: absolute;
+.tab_header_with_icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+}
+
+.table_header_icon {
+  vertical-align: middle;
+  transform: translateY(-0.1em);
 }


### PR DESCRIPTION
* Adds icons for the requirements table ratings.
  * Minimum – Turtle shell.
  * Moderate – Balanced scales.
  * Heavy – Lightning bolt.
* Adds icons for header tabs.
  * This was a major oversight in the original PR.
  * I would've done it if I'd known how easy this was.
  * These, to me, make it a lot easier to parse the docs.
  * Windows, macOS, and Linux icons match the ones we use for the downloads.
  * Avoided icons for the disc dumping utility headers, as they would just add confusion.
  * Only done for the setup docs, since those are presently the only ones using tabs.
* Fixes a minor typo where I wrote "Extract the contents of the `.zip` file." for a `.7z` download.

### Screenshots
<img width="912" height="366" alt="image" src="https://github.com/user-attachments/assets/1be91a01-16fc-454b-a890-e5a39d243f3c" />
<img width="1201" height="507" alt="image" src="https://github.com/user-attachments/assets/3e7d07c1-375f-4d5c-a249-e005ef675d51" />
<img width="1217" height="828" alt="image" src="https://github.com/user-attachments/assets/4990d5d2-7a31-4b8f-85ce-208c7aa46a06" />
<img width="1184" height="301" alt="image" src="https://github.com/user-attachments/assets/edbbd330-658f-413f-a32c-af26eb51e8c5" />
<img width="826" height="311" alt="image" src="https://github.com/user-attachments/assets/f4ce8d0e-3333-4bc9-9e58-107bd08b17e7" />
<img width="1200" height="621" alt="image" src="https://github.com/user-attachments/assets/541b33f5-df4f-4aac-aa59-25c67308f704" />