### PR TITLE
Docs: Fix incorrect syntax highlighting for certain code blocks

### DIFF
--- a/docs/advanced/cli.md
+++ b/docs/advanced/cli.md
@@ -14,7 +14,7 @@ Usage: `pcsx2-qt.exe [parameters] [--] [boot filename]`
 
 Parameter list:
 
-```sh
+```
   -help: Displays this information and exits.
   -version: Displays version information and exits.
   -batch: Enables batch mode (exits after shutting down).

--- a/docs/advanced/miscellaneous.md
+++ b/docs/advanced/miscellaneous.md
@@ -109,7 +109,7 @@ The output will be the stack trace of the minidump. if you are lucky, then the t
 
 In the example given below, we can find that an assertion was called (#6) in the startVM function (#7). Because of our debugging information, it even tells us the exact lines in code where this happened.
 
-```sh
+```
 Thread 3 EmuThread (crashed) - tid: 48404
  0  KERNELBASE.dll + 0x3b699
      rax = 0x0000000000000020    rdx = 0x000000b3e64fa739

--- a/docs/troubleshooting/linux.md
+++ b/docs/troubleshooting/linux.md
@@ -12,7 +12,7 @@ This page details known issues specific to Linux.
 
 If you see an error when opening the AppImage such as the following:
 
-```bash
+```
 ...
 dlopen(): error loading libfuse.so.2
 ...


### PR DESCRIPTION
Don't apply syntax highlighting where it doesn't make sense.