### PR TITLE
Blog: Clarify meaning of authors list for posts with multiple authors

### DIFF
--- a/src/theme/BlogPostItem/Header/index.js
+++ b/src/theme/BlogPostItem/Header/index.js
@@ -11,16 +11,21 @@ export default function BlogPostItemHeader() {
 
   let bgStyle = {};
   let classBlog = "";
+  let articleAuthors = "";
   if (metadata.frontMatter.titleImage) {
     classBlog = "header-blog";
     bgStyle = {
       backgroundImage: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url("${image}")`,
     };
   }
+  if (metadata.authors.length > 1) {
+    articleAuthors = "Article authors:";
+  }
   return (
     <header className={classBlog} style={bgStyle}>
       <BlogPostItemHeaderTitle />
       <BlogPostItemHeaderInfo />
+      {articleAuthors}
       <BlogPostItemHeaderAuthors />
     </header>
   );


### PR DESCRIPTION
If you look at comments reacting to our previous release announcements this has previously caused quite a bit of confusion, with people thinking the authors list was the list of contributors.

It could probably be done more elegantly, but I'm not really a web developer, so I think this is good enough for now.

<img width="1168" height="461" alt="Screenshot 2026-08-29 at 17-49-52 PCSX2 2 8 0 is now out! PCSX2" src="https://github.com/user-attachments/assets/5a17aa0a-b9d0-4096-9a8b-df7ef225c523" />
