### PR TITLE
Blog: Fix light mode authors list style

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -380,6 +380,7 @@ table td {
   margin: 0;
   margin-right: 0px;
   margin-left: 0px;
+  color: rgb(227, 227, 227);
   background: #eee;
   background-image: none;
   background-size: auto;
@@ -399,10 +400,6 @@ table td {
 
 .header-blog a {
   color: rgb(89, 197, 255);
-}
-
-.header-blog .margin-vert--md {
-  color: rgb(227, 227, 227);
 }
 
 .pr-link {


### PR DESCRIPTION
Fixes a regression from #550 that made the "Article authors:" text appear with the wrong colour in light mode.